### PR TITLE
Handle messages received by Spoke that aren't associated with a campaign

### DIFF
--- a/lib/identity_spoke.rb
+++ b/lib/identity_spoke.rb
@@ -133,8 +133,10 @@ module IdentitySpoke
     Rails.logger.info "#{SYSTEM_NAME.titleize} #{sync_id}: Handling message: #{message.id}/#{message.created_at.utc.to_s(:inspect)}"
 
     ## Find who is the campaign contact for the message
-    unless campaign_contact = IdentitySpoke::CampaignContact.find(message.campaign_contact_id)
-      Notify.warning "Spoke: CampaignContact Find Failed", "campaign_id: #{message.campaign_contact_id}, cell: #{message.contact_number}"
+    campaign_contact_id = message.campaign_contact_id
+    campaign_contact = IdentitySpoke::CampaignContact.find(campaign_contact_id) if campaign_contact_id
+    if !campaign_contact
+      Rails.logger.warn "#{SYSTEM_NAME.titleize} #{sync_id}: No campaign contact for message #{message.id}"
       return
     end
 

--- a/spec/lib/identity_spoke_pull_spec.rb
+++ b/spec/lib/identity_spoke_pull_spec.rb
@@ -161,6 +161,25 @@ describe IdentitySpoke do
       expect(Contact.where(notes: 'outbound').count).to eq(3)
     end
 
+    context('message without a campaign contact and assignment') do
+      before(:each) do
+        @message = FactoryBot.create(
+          :spoke_message_delivered,
+          id: 10000,
+          created_at: Time.now,
+          assignment: nil,
+          campaign_contact_id: nil,
+          user_id: nil,
+          user_number: '+61555123456',
+          contact_number: '+61555654321'
+        )
+      end
+       
+      it 'should gracefully handle processing the message' do
+        IdentitySpoke.handle_new_message(@sync_id, @message)
+      end
+    end
+
     context('with force=true passed as parameter') do
       ContactResponse.all.destroy_all
       Contact.all.destroy_all


### PR DESCRIPTION
Messages received by Spoke that aren't associated with any campaign
will have both null `campaign_contact_id` and `assignment_id` fields.

"Gracefully" handle this situation by not processing the message.