### PR TITLE
Stop matching by phone number when upserting members in Identity

### DIFF
--- a/app/models/identity_spoke/campaign_contact.rb
+++ b/app/models/identity_spoke/campaign_contact.rb
@@ -36,5 +36,58 @@ module IdentitySpoke
                        .pluck(:cell)
       batch.reject { |row| existing_cells.include?(row[:cell]) }
     end
+
+    def upsert_member
+      # Upsert this contacted member in Identity.
+      #
+      # Use the campaign contact's external_id if known so that the
+      # correct member gets used, irrespective of the phone number.
+      # If no external is set that's fine - a new member will always
+      # be created for the contact instead. But if so update the
+      # contact with the new member's external id for it for future
+      # upserts.
+      #
+      # See also User.upsert_member.
+      #
+      # Notes about the arguments here:
+      #
+      # 1. Don't include this campaign contact as an Identity external
+      # id since they are per-Spoke-campaign and will be different for
+      # each campaign.
+      #
+      # 2. Don't subscribe campaign contacts. They should be
+      # subscribed already if they were pushed from Id, if not
+      # (e.g. from a manual CSV upload) then they should be subscribed
+      # manually in Id if appropriate.
+      #
+      # 3. Don't match based on phone numbers. As of 2024, our member
+      # phone number data is in super bad shape, with the same number
+      # appearing on multiple members. As a result, matching on phone
+      # number only is as likely to be wrong as it is right.
+      #
+      # 4. Don't change anyone's names, the names here will likely be
+      # sourced from Id anyway, and if not, should be treated as less
+      # reliable than that in Id anyway
+      member = UpsertMember.call(
+        {
+          phones: [
+            { phone: cell.sub(/^[+]*/, '') }
+          ],
+          firstname: first_name,
+          lastname: last_name,
+          member_id: external_id.present? ? external_id.to_i : nil,
+          ignore_phone_number_match: true,
+        },
+        entry_point: "#{SYSTEM_NAME}",
+        new_member_opt_in: false,
+        ignore_name_change: true,
+      )
+
+      if external_id.blank?
+        update!(external_id: member.id.to_s)
+      end
+
+      return member
+    end
   end
 end

--- a/app/models/identity_spoke/user.rb
+++ b/app/models/identity_spoke/user.rb
@@ -1,7 +1,61 @@
 module IdentitySpoke
-  class User < ReadOnly
+  class User < ReadWrite
     self.table_name = "user"
     has_many :assignment, dependent: nil
     has_many :message, dependent: nil
+
+    def upsert_member
+      # Upsert this Spoke backend account in Identity.
+      #
+      # Hook up both the Spoke account's id to Identity external id,
+      # and vice-versa. We can do this here since unlike a
+      # CampaignContact, User entities are long lived.
+      #
+      # See also CampaignContact.upsert_member.
+      #
+      # Notes about the arguments here:
+      #
+      # 1. Don't subscribe accounts. They should be staff or vollies
+      # and hence subscribed already. If not, something has gone
+      # wrong, but also they probably haven't been asked for consent.
+      #
+      # 2. Don't match based on phone numbers. As of 2024, our member
+      # phone number data is in super bad shape, with the same number
+      # appearing on multiple members. As a result, matching on phone
+      # number only is as likely to be wrong as it is right.
+      #
+      # 3. Don't change anyone's names, the names here will likely be
+      # sourced from Id anyway, and if not, should be treated as less
+      # reliable than that in Id anyway.
+      if self.extra.nil?
+        self.extra = {}
+      end
+
+      member = UpsertMember.call(
+        {
+          emails: [
+            { email: email }
+          ],
+          phones: [
+            { phone: cell.sub(/^[+]*/, '') }
+          ],
+          firstname: first_name,
+          lastname: last_name,
+          member_id: self.extra.dig(:identity, :member_id),
+          external_ids: {
+            spoke: id.to_s
+          },
+          ignore_phone_number_match: true
+        },
+        entry_point: "#{SYSTEM_NAME}",
+        new_member_opt_in: false,
+        ignore_name_change: true
+      )
+
+      self.extra[:identity] = { member_id: member.id }
+      save!
+
+      return member
+    end
   end
 end

--- a/app/serializers/identity_spoke/spoke_member_sync_push_serializer.rb
+++ b/app/serializers/identity_spoke/spoke_member_sync_push_serializer.rb
@@ -3,7 +3,7 @@ module IdentitySpoke
     attributes :external_id, :first_name, :last_name, :cell, :campaign_id, :custom_fields
 
     def external_id
-      @object.id
+      @object.id.to_s
     end
 
     def first_name

--- a/spec/lib/identity_spoke_pull_spec.rb
+++ b/spec/lib/identity_spoke_pull_spec.rb
@@ -110,8 +110,8 @@ describe IdentitySpoke do
       }
       member = Member.find_by_phone('61427700401')
       expect(member).to have_attributes(first_name: 'Bob1')
-      expect(member.contacts_received.count).to eq(1)
-      expect(member.contacts_made.count).to eq(1)
+      expect(member.contacts_received.count).to eq(2)
+      expect(member.contacts_made.count).to eq(0)
     end
 
     it 'should create new members for user if none exist' do
@@ -120,8 +120,8 @@ describe IdentitySpoke do
       }
       member = Member.find_by_phone('61411222333')
       expect(member).to have_attributes(first_name: 'Super', last_name: 'Vollie')
-      expect(member.contacts_received.count).to eq(3)
-      expect(member.contacts_made.count).to eq(3)
+      expect(member.contacts_received.count).to eq(0)
+      expect(member.contacts_made.count).to eq(6)
     end
 
     it 'should match existing members for campaign contacts and user' do
@@ -299,7 +299,7 @@ describe IdentitySpoke do
         # noop
       }
       expect(Contact.count).to eq(6)
-      expect(member.contacts_received.count).to eq(1)
+      expect(member.contacts_received.count).to eq(2)
     end
 
     it 'should be idempotent' do

--- a/spec/serializers/spoke_member_sync_push_serializer_spec.rb
+++ b/spec/serializers/spoke_member_sync_push_serializer_spec.rb
@@ -18,7 +18,7 @@ describe IdentitySpoke::SpokeMemberSyncPushSerializer do
         serializer: IdentitySpoke::SpokeMemberSyncPushSerializer,
         campaign_id: @spoke_campaign.id
       ).as_json
-      expect(rows[0][:external_id]).to eq(@member.id)
+      expect(rows[0][:external_id]).to eq(@member.id.to_s)
       expect(rows[0][:cell]).to eq("+#{@member.phone_numbers.mobile.first.phone}")
       expect(rows[0][:campaign_id]).to eq(@spoke_campaign.id)
       expect(rows[0][:custom_fields]).to eq("{\"secret\":\"me_likes\"}")

--- a/spec/test_identity_app/app/lib/cleanser.rb
+++ b/spec/test_identity_app/app/lib/cleanser.rb
@@ -1,21 +1,27 @@
 class Cleanser
   ########## Email cleansing ##########
-  def self.cleanse_email(raw_email)
-    raw_email = raw_email.to_s
-    return nil if raw_email.empty?
-
-    # do basic cleansing
-    email = raw_email.downcase
-    email = email.gsub(/\s/, '')
-    email = email.gsub('%40', '@') # remove html entities
-
-    account = email.split('@').first
-    domain = self.fix_typos_in_domain(email.split('@').last)
-
-    email = "#{account}@#{domain}"
-    return nil unless accept_email?(email)
-
+  def self.normalise_email(raw_email)
+    email = raw_email.to_s
+    if email.present?
+      email = email.downcase
+      email = email.gsub(/\s/, '')
+      email = email.gsub('%40', '@') # remove html entities
+    else
+      email = nil
+    end
     email
+  end
+
+  def self.cleanse_email(raw_email)
+    email = Cleanser.normalise_email(raw_email)
+    if email.present?
+      account = email.split('@').first
+      domain = self.fix_typos_in_domain(email.split('@').last)
+      email = "#{account}@#{domain}"
+      accept_email?(email) ? email : nil
+    else
+      nil
+    end
   end
 
   def self.accept_email?(email_address)

--- a/spec/test_identity_app/app/lib/notify.rb
+++ b/spec/test_identity_app/app/lib/notify.rb
@@ -1,4 +1,11 @@
-class Notify
-  def self.warning(*args)
+if Settings.rollbar.api_key.present?
+  Notify = Rollbar
+else
+  module Notify
+    class << self
+      def method_missing(m, *args, &_block)
+        Rails.logger.warn("Call to Notify##{m} with args #{args.inspect} was made, but no notifier set up or is implemented (Bugsnag, Airbrake)")
+      end
+    end
   end
 end

--- a/spec/test_identity_app/app/lib/settings.rb
+++ b/spec/test_identity_app/app/lib/settings.rb
@@ -66,6 +66,12 @@ class Settings
     }
   end
 
+  def self.email
+    return {
+      "unsubscribe_url" => "http://localhost/unsubscribe",
+    }
+  end
+
   def self.options
     return {
       "default_member_opt_in_subscriptions" => false,
@@ -73,6 +79,12 @@ class Settings
       "default_phone_country_code" => '61',
       "default_mobile_phone_national_destination_code" => '4',
       "ignore_name_change_for_donation" => true
+    }
+  end
+
+  def self.rollbar
+    return {
+      "api_key" => nil
     }
   end
 end

--- a/spec/test_identity_app/app/models/member.rb
+++ b/spec/test_identity_app/app/models/member.rb
@@ -80,6 +80,7 @@ class Member < ApplicationRecord
 
   has_many :donations, class_name: 'Donations::Donation'
   has_many :regular_donations, class_name: 'Donations::RegularDonation'
+  has_many :failed_donations, class_name: 'Donations::FailedDonation'
   has_many :member_journeys
   has_many :journeys, through: :member_journeys
   has_many :notes, -> { order 'notes.created_at DESC' }
@@ -300,7 +301,8 @@ class Member < ApplicationRecord
     }
 
     if (new_address = addresses.find_by(address_attributes))
-      new_address.touch!
+      # Touch it only if it is not a current address
+      new_address.touch! unless new_address.id == old_address_id
     else
       new_address = addresses.create!(address_attributes)
     end
@@ -324,7 +326,8 @@ class Member < ApplicationRecord
     # If it is a new phone number, create a new phone number and it will be the primary one
 
     new_phone_number = PhoneNumber.standardise_phone_number(new_phone_number.to_s)
-    return false if phone_numbers.first.try(:phone) == new_phone_number
+    return false if new_phone_number.nil?
+    return true if phone_numbers.first.try(:phone) == new_phone_number
 
     if (phone_record = phone_numbers.find_by(phone: new_phone_number))
       # Make it most recently updated it so it becomes the primary phone number
@@ -793,7 +796,7 @@ class Member < ApplicationRecord
       %w(skill resource organisation).each do |w|
         named_attribute_data = select_data(row, w)
         unless named_attribute_data.empty?
-          hash_key = "#{w}s".to_sym
+          hash_key = :"#{w}s"
           member_hash[hash_key] = []
           named_attribute_data.each do |_key, value|
             member_hash[hash_key] << { name: value }
@@ -825,14 +828,31 @@ class Member < ApplicationRecord
     # load_from_csv is for loading members from external services such as ControlShift
     # ControlShift has a nightly full data load, including old data, so can't just upsert everything
     def load_from_csv(row)
+      cs_id = row['id']
+      if cs_id.blank?
+        raise 'ControlShift id missing'
+      end
+
       payload = {
         emails: [{ email: row['email'] }],
         firstname: row['first_name'],
         lastname: row['last_name'],
-        external_ids: { controlshift: row['id'] },
+        external_ids: { controlshift: cs_id },
         updated_at: row['updated_at']
       }
-      UpsertMember.call(payload)
+
+      retries = 0
+      begin
+        UpsertMember.call(payload)
+      rescue StandardError => e
+        # Possibility of race conditions in the transaction.
+        # Most likely from different CSL imports trying to upsert the same member.
+        # Transaction will clean up after itself, and then retry again.
+        # Have a limit of 3 retries so that we don't retry forever.
+        retries += 1
+        retry if retries < 3
+        Rails.logger.error("Failed to upsert member from ControlShift: #{e}")
+      end
     end
 
     def select_data(rows, key_name)
@@ -865,152 +885,179 @@ class Member < ApplicationRecord
       # payload includes the relevant consent. If no consent is present, we COULD still
       # store this action, but without any personal data (eg. empty name, email, etc...)
 
+      # find/create the member
+      cons_hash = payload[:cons_hash].merge(updated_at: payload[:create_dt])
+      ignore_names = Settings.options.ignore_name_change_for_donation && ['donate', 'regular_donate'].include?(payload[:action_type])
       begin
-        # find/create the member
-        cons_hash = payload[:cons_hash].merge(updated_at: payload[:create_dt])
-        ignore_names = Settings.options.ignore_name_change_for_donation && ['donate', 'regular_donate'].include?(payload[:action_type])
         member = UpsertMember.call(
           cons_hash,
           entry_point: "action:#{payload[:action_name]}",
           ignore_name_change: ignore_names
         )
-        if member.present?
-          # find/create the action
-          begin
-            query = { technical_type: payload[:action_technical_type],
-                      external_id: payload[:external_id] }
-            action = nil
+      rescue StandardError
+        member = nil
+      end
+      if member.present?
+        # find/create the action
+        begin
+          query = { technical_type: payload[:action_technical_type],
+                    external_id: payload[:external_id] }
+          action = nil
 
-            ### If no language specified in payload, find actions matching technical_type & external_id
-            if payload[:language].nil?
-              actions = Action.where(query)
-              if actions.length == 1
-                action = actions.first # if action only exists in a single language (or no language: legacy data)
-              elsif actions.length > 1
-                Rails.logger.error "The member action [member_id: #{member.id}, external_id: #{payload[:external_id]}, "\
-                                   "technical_type: #{payload[:action_technical_type]}] contains no language code but"\
-                                   "the action already exists in more than one language"
+          ### If no language specified in payload, find actions matching technical_type & external_id
+          if payload[:language].nil?
+            actions = Action.where(query)
+            if actions.length == 1
+              action = actions.first # if action only exists in a single language (or no language: legacy data)
+            elsif actions.length > 1
+              Rails.logger.error "The member action [member_id: #{member.id}, external_id: #{payload[:external_id]}, " \
+                                 "technical_type: #{payload[:action_technical_type]}] contains no language code but" \
+                                 "the action already exists in more than one language"
 
-                # Still want to record an action, so first try to find a matching action with the default language
-                action = actions.select { |a| a.language == AppSetting.actions.default_language }[0]
-                # If 'action' is still nil here, then a new action with the default language will be created below
-              end
-            else
-              # prefer searching for an (old) action with (explicitly) no language over creating a new (duplicate) one with a language
-              action = Action.find_by(query.merge(language: payload[:language])) || Action.find_by(query.merge(language: nil))
+              # Still want to record an action, so first try to find a matching action with the default language
+              action = actions.select { |a| a.language == AppSetting.actions.default_language }[0]
+              # If 'action' is still nil here, then a new action with the default language will be created below
             end
-
-            # Create a new action if none found
-            action = Action.create!(
-              name: payload[:action_name],
-              public_name: payload[:action_public_name],
-              action_type: payload[:action_type],
-              technical_type: payload[:action_technical_type],
-              description: payload[:action_description] || '',
-              external_id: payload[:external_id],
-              language: payload[:language].presence || AppSetting.actions.default_language
-            ) unless action
-          rescue ActiveRecord::RecordNotUnique
-            retry
-          end
-
-          # If the action's name has changed
-          if payload[:action_name].present? && payload[:action_name] != action.name
-            action.update!(name: payload[:action_name])
-          end
-
-          # If the action's public name has changed
-          if payload[:action_public_name].present? && payload[:action_public_name] != action.public_name
-            action.update!(public_name: payload[:action_public_name])
-          end
-
-          # Assign the controlshift campaign if one isn't set
-          if !action.campaign && action.technical_type == 'cby_petition'
-            campaign = Campaign.find_by(controlshift_campaign_id: action.external_id, campaign_type: 'controlshift')
-            campaign.store_action_language(action.language) if campaign
-            action.update!(campaign_id: campaign.id) if campaign
-          end
-
-          if payload[:campaign_id].present? && !action.campaign
-            # Allow external actions to pass a known identity campaign id and link the action
-            # to that campaign
-            campaign = Campaign.find_by(id: payload[:campaign_id])
-            campaign.store_action_language(action.language) if campaign
-            action.update!(campaign_id: campaign.id) if campaign
-          end
-
-          # create member action
-          if payload[:create_dt].presence.is_a? String
-            created_at = ActiveSupport::TimeZone.new('UTC').parse(payload[:create_dt])
           else
-            created_at = payload[:create_dt]
+            # prefer searching for an (old) action with (explicitly) no language over creating a new (duplicate) one with a language
+            action = Action.find_by(query.merge(language: payload[:language])) || Action.find_by(query.merge(language: nil))
           end
 
-          member_action = MemberAction.find_or_initialize_by(
-            action_id: action.id,
-            member_id: member.id,
-            created_at: created_at
-          )
-          new_record = member_action.new_record?
+          # Create a new action if none found
+          action = Action.create!(
+            name: payload[:action_name],
+            public_name: payload[:action_public_name],
+            action_type: payload[:action_type],
+            technical_type: payload[:action_technical_type],
+            description: payload[:action_description] || '',
+            external_id: payload[:external_id],
+            language: payload[:language].presence || AppSetting.actions.default_language
+          ) unless action
+        rescue ActiveRecord::RecordNotUnique
+          retry
+        end
 
-          # subscribe the member to mailings
-          # don't subscribe if disable_auto_subscribe is enabled (subscriptions must be handled through consents and post_consent_methods)
-          # only if action is newer than his unsubscribe;
-          # if opt_in is present, it must be set to true
-          if !Settings.gdpr.disable_auto_subscribe && (payload[:opt_in].nil? || payload[:opt_in]) && !member.subscribed?
-            email_subscription = member.member_subscriptions.find_by(subscription: Subscription::EMAIL_SUBSCRIPTION)
-            if email_subscription.nil?
-              member.subscribe
-            elsif member_action.created_at > email_subscription.unsubscribed_at
-              member.subscribe
+        # If the action's name has changed
+        if payload[:action_name].present? && payload[:action_name] != action.name
+          action.update!(name: payload[:action_name])
+        end
+
+        # If the action's public name has changed
+        if payload[:action_public_name].present? && payload[:action_public_name] != action.public_name
+          action.update!(public_name: payload[:action_public_name])
+        end
+
+        # Assign the controlshift campaign if one isn't set
+        if !action.campaign && action.technical_type == 'cby_petition'
+          campaign = Campaign.find_by(controlshift_campaign_id: action.external_id, campaign_type: 'controlshift')
+          campaign.store_action_language(action.language) if campaign
+          action.update!(campaign_id: campaign.id) if campaign
+        end
+
+        if payload[:campaign_id].present? && !action.campaign
+          # Allow external actions to pass a known identity campaign id and link the action
+          # to that campaign
+          campaign = Campaign.find_by(id: payload[:campaign_id])
+          campaign.store_action_language(action.language) if campaign
+          action.update!(campaign_id: campaign.id) if campaign
+        end
+
+        # create member action
+        if payload[:create_dt].presence.is_a? String
+          created_at = ActiveSupport::TimeZone.new('UTC').parse(payload[:create_dt])
+        else
+          created_at = payload[:create_dt]
+        end
+
+        member_action = MemberAction.find_or_initialize_by(
+          action_id: action.id,
+          member_id: member.id,
+          created_at: created_at
+        )
+        new_record = member_action.new_record?
+
+        # subscribe the member to mailings
+        # don't subscribe if disable_auto_subscribe is enabled (subscriptions must be handled through consents and post_consent_methods)
+        # only if action is newer than his unsubscribe;
+        # if opt_in is present, it must be set to true
+        if !Settings.gdpr.disable_auto_subscribe && (payload[:opt_in].nil? || payload[:opt_in]) && !member.subscribed?
+          email_subscription = member.member_subscriptions.find_by(subscription: Subscription::EMAIL_SUBSCRIPTION)
+          if email_subscription.nil?
+            member.subscribe
+          elsif member_action.created_at > email_subscription.unsubscribed_at
+            member.subscribe
+          end
+        end
+
+        if member_action.valid? && payload[:source].present?
+          # store utm codes against the action
+          source_hash = payload[:source].slice(:source, :medium, :campaign).select { |_k, v| v.present? }
+
+          if source_hash.present?
+            source = Source.find_or_create_with_defaults(source_hash)
+
+            # This *must* be an update in order to allow requests which update an old member action's source
+            member_action.update!(source_id: source.id)
+          end
+        end
+
+        if new_record && member_action.valid?
+          # add consents to the member action
+          if payload[:consents].present?
+            payload[:consents].each do |consent_hash|
+              next if consent_hash[:consent_level] == 'no_change' && !Settings.consent.record_no_change_consents
+
+              consent_text = ConsentText.find_by!(public_id: consent_hash[:public_id])
+
+              member_action.member_action_consents.build(
+                member_action: member_action,
+                consent_text: consent_text,
+                consent_level: consent_hash[:consent_level],
+                consent_method: consent_hash[:consent_method],
+                consent_method_option: consent_hash[:consent_method_option],
+                parent_member_action_consent: nil, # TODO: Something like `member.current_consents.find_by(consent_public_id: consent_text.public_id).member_action_consent` but only if it's a 'no_change'...
+                created_at: payload[:create_dt],
+                updated_at: payload[:create_dt]
+              )
             end
           end
 
-          if member_action.valid? && payload[:source].present?
-            # store utm codes against the action
-            source_hash = payload[:source].slice(:source, :medium, :campaign).select { |_k, v| v.present? }
+          ApplicationRecord.transaction do
+            member_action.save!
 
-            if source_hash.present?
-              source = Source.find_or_create_with_defaults(source_hash)
-
-              # This *must* be an update in order to allow requests which update an old member action's source
-              member_action.update!(source_id: source.id)
-            end
-          end
-
-          if new_record && member_action.valid?
-            # add consents to the member action
-            if payload[:consents].present?
-              payload[:consents].each do |consent_hash|
-                next if consent_hash[:consent_level] == 'no_change' && !Settings.consent.record_no_change_consents
-
-                consent_text = ConsentText.find_by!(public_id: consent_hash[:public_id])
-
-                member_action.member_action_consents.build(
-                  member_action: member_action,
-                  consent_text: consent_text,
-                  consent_level: consent_hash[:consent_level],
-                  consent_method: consent_hash[:consent_method],
-                  consent_method_option: consent_hash[:consent_method_option],
-                  parent_member_action_consent: nil, # TODO: Something like `member.current_consents.find_by(consent_public_id: consent_text.public_id).member_action_consent` but only if it's a 'no_change'...
-                  created_at: payload[:create_dt],
-                  updated_at: payload[:create_dt]
+            # split meta data into keys
+            if payload[:metadata]
+              payload[:metadata].each do |key, value|
+                # Get the key
+                action_key = ActionKey.find_or_create_by!(action: action, key: key.to_s)
+                # Allow nested data as metadata
+                if value.is_a?(Hash) || value.is_a?(Array)
+                  value = value.to_json
+                end
+                MemberActionData.create!(
+                  member_action_id: member_action.id,
+                  action_key: action_key,
+                  value: value
                 )
               end
             end
 
-            ApplicationRecord.transaction do
-              member_action.save!
+            # parse survey responses
+            if payload[:survey_responses]
+              payload[:survey_responses].each do |sr|
+                action_key = ActionKey.find_or_create_by!(action: action, key: sr[:question][:text])
 
-              # split meta data into keys
-              if payload[:metadata]
-                payload[:metadata].each do |key, value|
-                  # Get the key
-                  action_key = ActionKey.find_or_create_by!(action: action, key: key.to_s)
-                  # Allow nested data as metadata
-                  if value.is_a?(Hash) || value.is_a?(Array)
-                    value = value.to_json
-                  end
+                Question.find_or_create_by! action_key: action_key do |q|
+                  q.question_type = sr[:question][:qtype]
+                end
+
+                values = if sr[:answer].is_a? Array
+                           sr[:answer]
+                         else
+                           [sr[:answer]]
+                         end
+
+                values.each do |value|
                   MemberActionData.create!(
                     member_action_id: member_action.id,
                     action_key: action_key,
@@ -1018,50 +1065,23 @@ class Member < ApplicationRecord
                   )
                 end
               end
-
-              # parse survey responses
-              if payload[:survey_responses]
-                payload[:survey_responses].each do |sr|
-                  action_key = ActionKey.find_or_create_by!(action: action, key: sr[:question][:text])
-
-                  Question.find_or_create_by! action_key: action_key do |q|
-                    q.question_type = sr[:question][:qtype]
-                  end
-
-                  values = if sr[:answer].is_a? Array
-                             sr[:answer]
-                           else
-                             [sr[:answer]]
-                           end
-
-                  values.each do |value|
-                    MemberActionData.create!(
-                      member_action_id: member_action.id,
-                      action_key: action_key,
-                      value: value
-                    )
-                  end
-                end
-              end
-
-              # XXX old 38 data has nil created_at. Can't compare nil and date like this.
-              if member.created_at.present? && member.created_at > member_action.created_at
-                member.created_at = member_action.created_at
-                member.save!
-              end
             end
-          else
-            Rails.logger.info "Duplicate member action: action #{member_action.action_id} for member #{member_action.member_id}"
-            return member_action
+
+            # XXX old 38 data has nil created_at. Can't compare nil and date like this.
+            if member.created_at.present? && member.created_at > member_action.created_at
+              member.created_at = member_action.created_at
+              member.save!
+            end
           end
         else
-          Rails.logger.info "Failed to upsert member. Hash: #{payload.inspect}"
-          return nil
+          Rails.logger.info "Duplicate member action: action #{member_action.action_id} for member #{member_action.member_id}"
+          return member_action
         end
-        return member_action
-      rescue => e
-        raise e
+      else
+        Rails.logger.info "Failed to upsert member. Hash: #{payload.inspect}"
+        return nil
       end
+      return member_action
     end
 
     # Takes a phone number and returns member or nil

--- a/spec/test_identity_app/app/models/member_external_id.rb
+++ b/spec/test_identity_app/app/models/member_external_id.rb
@@ -1,4 +1,6 @@
 class MemberExternalId < ApplicationRecord
+  include AuditPlease
+
   belongs_to :member
 
   validates_presence_of :member

--- a/spec/test_identity_app/app/models/subscription.rb
+++ b/spec/test_identity_app/app/models/subscription.rb
@@ -27,7 +27,9 @@ class Subscription < ApplicationRecord
     sub.is_default = true
   end
 
-  UNSUBSCRIBE_EMAIL_URL = "#{Settings.app.inbound_url}/subscriptions/unsubscribe?subscription=#{Subscription::EMAIL_SUBSCRIPTION.id}".freeze
+  UNSUBSCRIBE_EMAIL_URL = !Settings.email["unsubscribe_url"] ?
+                          "#{Settings.app.inbound_url}/subscriptions/unsubscribe?subscription=#{Subscription::EMAIL_SUBSCRIPTION.id}&".freeze
+                          : "#{Settings.email.unsubscribe_url}?".freeze
 
   SMS_SUBSCRIPTION = Subscription.find_or_create_by! slug: Subscription::SMS_SLUG do |sub|
     sub.name = 'SMS'
@@ -60,6 +62,7 @@ class Subscription < ApplicationRecord
   has_many :subscribables, through: :member_subscription_events
   has_many :members, through: :member_subscriptions
 
+  default_scope { order(is_default: :desc, member_count: :desc) }
   scope :defaults, -> { where(is_default: true, deleted_at: nil) }
   scope :non_defaults, -> { where(is_default: false, deleted_at: nil) }
 

--- a/spec/test_identity_app/app/services/upsert_member.rb
+++ b/spec/test_identity_app/app/services/upsert_member.rb
@@ -1,3 +1,42 @@
+##
+# Standard service for updating or inserting a member.
+#
+# Given a `cons_hash` payload parameter (see API documentation for
+# details) looks up an existing member and update them with the values
+# in the payload, or if not found creates the member.
+#
+# Member lookup is performed using the following payload data:
+#  * First email address given (all others are ignored)
+#  * First phone number given (others will be upserted, phone numbers will
+#    be ignored if payload key `ignore_phone_number_match` evaluates to
+#    true)
+#  * First existing external systems id given
+#  * `member_id` - if given the member *must* already exist else an error is
+#    thrown
+#  * `guid` - if given the member *must* already exist else an error is
+#    thrown
+#
+# At least one of the above payload values must be provided, otherwise
+# an error is thrown.
+#
+# Any email given in the payload will be filtered first through
+# `Cleanser`, and any phone numbers given will be normalised via the
+# PhoneNumber.
+#
+# If `Settings.options.allow_subscribe_via_upsert_member` is true,
+# then the member's subscriptions will be updated using the payload
+# `subscriptions` parameter. If `new_member_opt_in` is also true, any
+# members created as part of the subscription process will also be
+# subscribed, but using the defaul subscriptions.
+#
+# Will raise an exception if either the `member_id` or `guid` payload
+# values are set an a matching member is not found, if not enough data
+# was provided to lookup or create a unique member record, or if any
+# matched member is already ghosted.
+#
+# Will not change an existing member's name unless
+# `ignore_name_change` is true.
+#
 class UpsertMember < IdentityBaseService
   def initialize(payload,
                  entry_point: '',
@@ -10,17 +49,18 @@ class UpsertMember < IdentityBaseService
     if @new_member_opt_in.nil?
       @new_member_opt_in = Settings.options.default_member_opt_in_subscriptions
     end
-    @retries = 0
   end
 
   def call
     ApplicationRecord.transaction do
-      # fail if there's no data
-      next if payload.blank?
-
-      member, member_created = find_or_create_member(payload)
-
-      next if member.blank?
+      begin
+        member, member_created = find_or_create_member(payload)
+      rescue StandardError => e
+        Rails.logger.warn {
+          "Rejected upsert due to member find/create error: #{e}"
+        }
+        raise
+      end
 
       upsert_external_ids(payload[:external_ids], member) if payload.key?(:external_ids)
 
@@ -49,14 +89,6 @@ class UpsertMember < IdentityBaseService
 
       member
     end
-  rescue StandardError
-    # Possibility of race conditions in the transaction.
-    # Most likely from different CSL imports trying to upsert the same member.
-    # Transaction will clean up after itself, and then retry again.
-    # Have a limit of 3 retries so that we don't retry forever.
-    @retries += 1
-    retry if @retries < 3
-    raise
   end
 
   private
@@ -64,36 +96,69 @@ class UpsertMember < IdentityBaseService
   attr_reader :payload, :entry_point, :ignore_name_change
 
   def find_or_create_member(payload)
+    member_id = payload[:member_id]
+    if member_id.present?
+      return [Member.find_sole_by(id: member_id), false]
+    end
+
+    guid = payload[:guid]
+    if guid.present?
+      return [Member.find_sole_by(guid: guid), false]
+    end
+
+    # For member lookup, it's good enough to ignore invalid email
+    # addresses and phone numbers, since if they are invalid, we can't
+    # perform a lookup for them
+
+    email = Cleanser.cleanse_email(payload.try(:[], :emails).try(:[], 0).try(:[], :email))
+    email = nil unless Cleanser.accept_email?(email)
+
+    phone = PhoneNumber.standardise_phone_number(
+      payload.try(:[], :phones).try(:[], 0).try(:[], :phone)
+    )
+
     external_matched_members = payload[:external_ids]&.map do |system, id|
       Member.find_by_external_id(system, id)
     end&.compact&.uniq
-
-    email = Cleanser.cleanse_email(payload.try(:[], :emails).try(:[], 0).try(:[], :email))
-    phone = PhoneNumber.standardise_phone_number(payload.try(:[], :phones).try(:[], 0).try(:[], :phone))
-    guid = payload[:guid]
-
-    email = nil unless Cleanser.accept_email?(email)
-
-    member_created = false
     member = external_matched_members.first if external_matched_members.present? && external_matched_members.length == 1
 
-    unless member || email || phone || guid
-      Rails.logger.info('Rejected upsert for member because there was no email or phone or guid found')
-      return nil, false
+    unless member || email || phone
+      raise "Not enough information provided to find or create a member"
     end
 
-    member = Member.find_by(email: email) if !member && email.present?
-    if !payload[:ignore_phone_number_match]
-      member = Member.find_by_phone(phone) if !member && phone.present?
-    end
-    member = Member.find_by(guid: guid) if !member && guid.present?
+    # Both the email and phone lookups below catch both "not found" &
+    # "too many" here since if not found then it should be created,
+    # but also if more than one is found, it's not possible to
+    # reliably disambiguate in an automated way, so create a duplicate
+    # and let something/someone else handle it.
 
-    unless member
+    if !member && email.present?
+      begin
+        member = Member.find_sole_by(email: email)
+      rescue ActiveRecord::RecordNotFound
+        # pass
+      rescue ActiveRecord::SoleRecordExceeded
+        # pass
+      end
+    end
+
+    if !member && phone.present? && !payload[:ignore_phone_number_match]
+      begin
+        member = PhoneNumber.find_sole_by(phone: phone).member
+      rescue ActiveRecord::RecordNotFound
+        # pass
+      rescue ActiveRecord::SoleRecordExceeded
+        # pass
+      end
+    end
+
+    member_created = false
+    if !member
       member = Member.create!(email: email, entry_point: entry_point)
       member_created = true
     end
 
-    [member, member_created]
+    return [member, member_created]
   end
 
   def upsert_external_ids(external_ids, member)
@@ -150,10 +215,21 @@ class UpsertMember < IdentityBaseService
 
   def upsert_addresses(addresses, member)
     address = addresses.first
-    # Don't update with any address containing only empty strings
-    if address.except(:country).values.any?(&:present?)
-      member.update_address(address)
+
+    # Skip update if the address contains only `country`
+    # or if all other attributes are blank.
+    return if address.keys == [:country]
+    return if address.except(:country).values.all?(&:blank?)
+
+    # Skip update if all attributes are nil except a single one,
+    # and that attribute matches the existing member's address.
+    specified_fields = address.reject { |_k, v| v.nil? }
+    if specified_fields.size == 1 && member.address
+      key, value = specified_fields.first
+      return if member.address.send(key) == value
     end
+
+    member.update_address(address)
   end
 
   def upsert_subscriptions(subscriptions, member)


### PR DESCRIPTION
In general since our member phone number data quality is so poor (we have many members with duplicate phone numbers), we can't rely on matching against the phone number when pulling Spoke data into Identity.

When pulling messages and opt-outs, if an external id for a Spoke `CampaignContact` is set, use that to look up the member - the external id came from Identity so we know what member is involved.

If not we must create a new member every time - because if there is zero matching members, we need to create one; if there is one matching member, that member could have a bad phone number, so we can't assume it's them, so create a new one; if there are multiple members with matching numbers, we can't pick the right one reliably, so create a new one.

For Spoke users, upsert based on their known email address, because that is more reliable.

In all cases, update external ids in Spoke when one is not known, so if multiple contacts are processed for a newly upserted member, the same member is used for all further contacts in the same campaign.